### PR TITLE
adapt to tsubakuro ResponseBox not public

### DIFF
--- a/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/error/DbErrorMultiplexInsertTest.java
+++ b/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/error/DbErrorMultiplexInsertTest.java
@@ -14,7 +14,7 @@ import com.tsurugidb.iceaxe.test.util.DbTestTableTester;
 import com.tsurugidb.iceaxe.test.util.TestEntity;
 import com.tsurugidb.iceaxe.transaction.exception.TsurugiTransactionException;
 import com.tsurugidb.iceaxe.transaction.option.TgTxOption;
-import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.ResponseBox;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.Link;
 import com.tsurugidb.tsubakuro.sql.SqlServiceCode;
 
 /**
@@ -22,7 +22,7 @@ import com.tsurugidb.tsubakuro.sql.SqlServiceCode;
  */
 class DbErrorMultiplexInsertTest extends DbTestTableTester {
 
-    private static final int ATTEMPT_SIZE = ResponseBox.responseBoxSize() + 100;
+    private static final int ATTEMPT_SIZE = Link.responseBoxSize() + 100;
 
     @BeforeEach
     void beforeEach(TestInfo info) throws Exception {

--- a/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/error/DbErrorMultiplexSelectTest.java
+++ b/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/error/DbErrorMultiplexSelectTest.java
@@ -15,7 +15,7 @@ import com.tsurugidb.iceaxe.test.util.DbTestConnector;
 import com.tsurugidb.iceaxe.test.util.DbTestTableTester;
 import com.tsurugidb.iceaxe.transaction.exception.TsurugiTransactionException;
 import com.tsurugidb.iceaxe.transaction.option.TgTxOption;
-import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.ResponseBox;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.Link;
 import com.tsurugidb.tsubakuro.sql.SqlServiceCode;
 
 /**
@@ -23,7 +23,7 @@ import com.tsurugidb.tsubakuro.sql.SqlServiceCode;
  */
 class DbErrorMultiplexSelectTest extends DbTestTableTester {
 
-    private static final int ATTEMPT_SIZE = ResponseBox.responseBoxSize() + 100;
+    private static final int ATTEMPT_SIZE = Link.responseBoxSize() + 100;
 
     @BeforeAll
     static void beforeAll(TestInfo info) throws Exception {

--- a/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/error/DbErrorTableNotExistsTest.java
+++ b/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/error/DbErrorTableNotExistsTest.java
@@ -20,7 +20,7 @@ import com.tsurugidb.iceaxe.test.util.TestEntity;
 import com.tsurugidb.iceaxe.transaction.exception.TsurugiTransactionException;
 import com.tsurugidb.iceaxe.transaction.function.TsurugiTransactionAction;
 import com.tsurugidb.iceaxe.transaction.manager.exception.TsurugiTmIOException;
-import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.ResponseBox;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.Link;
 import com.tsurugidb.tsubakuro.sql.SqlServiceCode;
 
 /**
@@ -28,7 +28,7 @@ import com.tsurugidb.tsubakuro.sql.SqlServiceCode;
  */
 class DbErrorTableNotExistsTest extends DbTestTableTester {
 
-    private static final int ATTEMPT_SIZE = ResponseBox.responseBoxSize() + 200;
+    private static final int ATTEMPT_SIZE = Link.responseBoxSize() + 200;
 
     @BeforeAll
     static void beforeAll(TestInfo info) throws Exception {

--- a/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/select/DbSelectEmptyTest.java
+++ b/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/select/DbSelectEmptyTest.java
@@ -14,14 +14,14 @@ import org.slf4j.LoggerFactory;
 import com.tsurugidb.iceaxe.sql.result.TgResultMapping;
 import com.tsurugidb.iceaxe.sql.result.TsurugiResultEntity;
 import com.tsurugidb.iceaxe.test.util.DbTestTableTester;
-import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.ResponseBox;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.Link;
 
 /**
  * select empty-table test
  */
 class DbSelectEmptyTest extends DbTestTableTester {
 
-    private static final int ATTEMPT_SIZE = ResponseBox.responseBoxSize() + 100;
+    private static final int ATTEMPT_SIZE = Link.responseBoxSize() + 100;
 
     @BeforeAll
     static void beforeAll(TestInfo info) throws Exception {

--- a/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/select/DbSelectFewTest.java
+++ b/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/select/DbSelectFewTest.java
@@ -13,14 +13,14 @@ import com.tsurugidb.iceaxe.test.util.DbTestTableTester;
 import com.tsurugidb.iceaxe.test.util.TestEntity;
 import com.tsurugidb.iceaxe.transaction.TgCommitType;
 import com.tsurugidb.iceaxe.transaction.option.TgTxOption;
-import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.ResponseBox;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.Link;
 
 /**
  * select few record test
  */
 class DbSelectFewTest extends DbTestTableTester {
 
-    private static final int ATTEMPT_SIZE = ResponseBox.responseBoxSize() + 200;
+    private static final int ATTEMPT_SIZE = Link.responseBoxSize() + 200;
 
     @BeforeAll
     static void beforeAll(TestInfo info) throws Exception {

--- a/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/timeout/DbSlotLimitTest.java
+++ b/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/timeout/DbSlotLimitTest.java
@@ -18,14 +18,14 @@ import com.tsurugidb.iceaxe.sql.result.TsurugiResultEntity;
 import com.tsurugidb.iceaxe.transaction.TsurugiTransaction;
 import com.tsurugidb.iceaxe.transaction.exception.TsurugiTransactionException;
 import com.tsurugidb.iceaxe.transaction.option.TgTxOption;
-import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.ResponseBox;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.Link;
 
 /**
  * slot limit test
  */
 public class DbSlotLimitTest extends DbTimetoutTest {
 
-    private static final int ATTEMPT_SIZE = ResponseBox.responseBoxSize() + 100;
+    private static final int ATTEMPT_SIZE = Link.responseBoxSize() + 100;
 
     @BeforeEach
     void beforeEach(TestInfo info) throws Exception {

--- a/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/transaction/DbMultiTransactionTest.java
+++ b/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/transaction/DbMultiTransactionTest.java
@@ -23,15 +23,15 @@ import com.tsurugidb.iceaxe.test.util.DbTestConnector;
 import com.tsurugidb.iceaxe.test.util.DbTestTableTester;
 import com.tsurugidb.iceaxe.test.util.TestEntity;
 import com.tsurugidb.iceaxe.transaction.option.TgTxOption;
-import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.ResponseBox;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.impl.Link;
 
 /**
  * multi transaction test
  */
 class DbMultiTransactionTest extends DbTestTableTester {
 
-    private static final int ATTEMPT_SIZE = ResponseBox.responseBoxSize() + 100;
-    private static final int THREAD_SIZE = ResponseBox.responseBoxSize() + 10;
+    private static final int ATTEMPT_SIZE = Link.responseBoxSize() + 100;
+    private static final int THREAD_SIZE = Link.responseBoxSize() + 10;
 
     @BeforeEach
     void beforeEach(TestInfo info) throws Exception {


### PR DESCRIPTION
@hishidama ResponseBoxをpublic classではなくpackage内からのみ使用可能なclassに変更しようと思います。ResponseBoxは、iceaxe-testingにてResponseBox.responseBoxSize()が使われていましたのでLinkに同様のmethodを用意しました。本PRはResponseBox.responseBoxSize()からLink.responseBoxSize()に変更するものです。確認の上、問題なければマージをお願いします。